### PR TITLE
Update to New Markdown-it

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,6 +34,7 @@ function video_embed(md) {
             res,
             videoID = '',
             tokens,
+            token,
             start,
             oldPos = state.pos,
             max = state.posMax;
@@ -92,13 +93,10 @@ function video_embed(md) {
             );
             newState.md.inline.tokenize(newState);
 
-            state.push({
-                type: 'video',
-                videoID: videoID,
-                tokens: tokens,
-                service: service,
-                level: state.level
-            });
+            token = state.push('video', '');
+            token.videoID = videoID;
+            token.service = service;
+            token.level = state.level;
         }
 
         state.pos = state.pos + state.src.indexOf(')');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "markdown-it-video",
-  "version": "0.1.6",
+  "version": "0.2.0",
   "description": "Markdown-it plugin to embed a hosted videos",
   "main": "index.js",
   "scripts": {
@@ -23,7 +23,7 @@
   "dependencies": {
   },
   "devDependencies": {
-    "markdown-it": "^3.0.4",
+    "markdown-it": "^4.1.0",
     "markdown-it-testgen": "^0.1.4",
     "coveralls": "^2.11.2",
     "eslint": "^0.13.0",


### PR DESCRIPTION
Replace the old syntax with new syntax.

Require markdown-it 4.1.0

Bump version to 0.2.0

Very simple syntax upgrade after dealing with another.
