### PR TITLE
[PLAT-493][Gates] Fix of doubling single line break videos

### DIFF
--- a/index.js
+++ b/index.js
@@ -45,7 +45,7 @@ function videoEmbed(md, options) {
       return false;
     }
 
-    const match = EMBED_REGEX.exec(state.src);
+    const match = EMBED_REGEX.exec(state.src.slice(state.pos, state.src.length));
 
     if (!match || match.length < 3) {
       return false;

--- a/test/fixtures/video.txt
+++ b/test/fixtures/video.txt
@@ -320,3 +320,24 @@ Coverage. Prezi from URL
 .
 <p><div class="embed-responsive embed-responsive-16by9"><iframe class="embed-responsive-item prezi-player" type="text/html" width="550" height="400" src="https://prezi.com/embed/1kkxdtlp4241/?bgcolor=ffffff&amp;lock_to_path=0&amp;autoplay=0&amp;autohide_ctrls=0&amp;landing_data=bHVZZmNaNDBIWnNjdEVENDRhZDFNZGNIUE43MHdLNWpsdFJLb2ZHanI5N1lQVHkxSHFxazZ0UUNCRHloSXZROHh3PT0&amp;landing_sign=1kD6c0N6aYpMUS0wxnQjxzSqZlEB8qNFdxtdjYhwSuI" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe></div></p>
 .
+
+Coverage. Line Breaks
+.
+@[vine](MhQ2lvg29Un) @[vine](MhQ2lvg29Un)
+.
+<p>@<a href="MhQ2lvg29Un">vine</a> <div class="embed-responsive embed-responsive-16by9"><iframe class="embed-responsive-item vine-player" type="text/html" width="600" height="600" src="https://vine.co/v/MhQ2lvg29Un/embed/simple" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe></div></p>
+.
+.
+@[vine](MhQ2lvg29Un)
+@[vine](00000000000)
+.
+<p><div class="embed-responsive embed-responsive-16by9"><iframe class="embed-responsive-item vine-player" type="text/html" width="600" height="600" src="https://vine.co/v/MhQ2lvg29Un/embed/simple" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe></div><div class="embed-responsive embed-responsive-16by9"><iframe class="embed-responsive-item vine-player" type="text/html" width="600" height="600" src="https://vine.co/v/00000000000/embed/simple" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe></div></p>
+.
+.
+@[vine](MhQ2lvg29Un)
+
+@[vine](00000000000)
+.
+<p><div class="embed-responsive embed-responsive-16by9"><iframe class="embed-responsive-item vine-player" type="text/html" width="600" height="600" src="https://vine.co/v/MhQ2lvg29Un/embed/simple" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe></div></p>
+<p><div class="embed-responsive embed-responsive-16by9"><iframe class="embed-responsive-item vine-player" type="text/html" width="600" height="600" src="https://vine.co/v/00000000000/embed/simple" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe></div></p>
+.

--- a/test/test.js
+++ b/test/test.js
@@ -1,6 +1,5 @@
 var path = require('path');
 var generate = require('markdown-it-testgen');
-var assert = require('assert');
 
 describe('markdown-it-video', function requireMarkdownIt() {
   var md = require('markdown-it')({

--- a/test/test.js
+++ b/test/test.js
@@ -9,18 +9,4 @@ describe('markdown-it-video', function requireMarkdownIt() {
     typography: true,
   }).use(require('../'));
   generate(path.join(__dirname, 'fixtures/video.txt'), md);
-
-  it('should not render two on a single line', function() {
-    assert.equal(md.render('@[vine](MhQ2lvg29Un) @[vine](MhQ2lvg29Un)'),
-      '<p>@<a href="MhQ2lvg29Un">vine</a> <div class="embed-responsive embed-responsive-16by9"><iframe class="embed-responsive-item vine-player" type="text/html" width="600" height="600" src="https://vine.co/v/MhQ2lvg29Un/embed/simple" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe></div></p>\n');
-  });
-  it('should not double two iframes with diffent ids after a single line break', function() {
-    assert.equal(md.render('@[vine](MhQ2lvg29Un) \n @[vine](00000000000)'),
-      '<p><div class="embed-responsive embed-responsive-16by9"><iframe class="embed-responsive-item vine-player" type="text/html" width="600" height="600" src="https://vine.co/v/MhQ2lvg29Un/embed/simple" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe></div>\n <div class="embed-responsive embed-responsive-16by9"><iframe class="embed-responsive-item vine-player" type="text/html" width="600" height="600" src="https://vine.co/v/00000000000/embed/simple" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe></div></p>\n');
-  });
-  it('should not double two iframes with diffent ids after a single double break', function() {
-    assert.equal(md.render('@[vine](MhQ2lvg29Un) \n @[vine](00000000000)'),
-      '<p><div class="embed-responsive embed-responsive-16by9"><iframe class="embed-responsive-item vine-player" type="text/html" width="600" height="600" src="https://vine.co/v/MhQ2lvg29Un/embed/simple" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe></div>\n <div class="embed-responsive embed-responsive-16by9"><iframe class="embed-responsive-item vine-player" type="text/html" width="600" height="600" src="https://vine.co/v/00000000000/embed/simple" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe></div></p>\n');
-  });
-
 });

--- a/test/test.js
+++ b/test/test.js
@@ -1,5 +1,6 @@
 var path = require('path');
 var generate = require('markdown-it-testgen');
+var assert = require('assert');
 
 describe('markdown-it-video', function requireMarkdownIt() {
   var md = require('markdown-it')({
@@ -8,4 +9,18 @@ describe('markdown-it-video', function requireMarkdownIt() {
     typography: true,
   }).use(require('../'));
   generate(path.join(__dirname, 'fixtures/video.txt'), md);
+
+  it('should not render two on a single line', function() {
+    assert.equal(md.render('@[vine](MhQ2lvg29Un) @[vine](MhQ2lvg29Un)'),
+      '<p>@<a href="MhQ2lvg29Un">vine</a> <div class="embed-responsive embed-responsive-16by9"><iframe class="embed-responsive-item vine-player" type="text/html" width="600" height="600" src="https://vine.co/v/MhQ2lvg29Un/embed/simple" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe></div></p>\n');
+  });
+  it('should not double two iframes with diffent ids after a single line break', function() {
+    assert.equal(md.render('@[vine](MhQ2lvg29Un) \n @[vine](00000000000)'),
+      '<p><div class="embed-responsive embed-responsive-16by9"><iframe class="embed-responsive-item vine-player" type="text/html" width="600" height="600" src="https://vine.co/v/MhQ2lvg29Un/embed/simple" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe></div>\n <div class="embed-responsive embed-responsive-16by9"><iframe class="embed-responsive-item vine-player" type="text/html" width="600" height="600" src="https://vine.co/v/00000000000/embed/simple" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe></div></p>\n');
+  });
+  it('should not double two iframes with diffent ids after a single double break', function() {
+    assert.equal(md.render('@[vine](MhQ2lvg29Un) \n @[vine](00000000000)'),
+      '<p><div class="embed-responsive embed-responsive-16by9"><iframe class="embed-responsive-item vine-player" type="text/html" width="600" height="600" src="https://vine.co/v/MhQ2lvg29Un/embed/simple" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe></div>\n <div class="embed-responsive embed-responsive-16by9"><iframe class="embed-responsive-item vine-player" type="text/html" width="600" height="600" src="https://vine.co/v/00000000000/embed/simple" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe></div></p>\n');
+  });
+
 });


### PR DESCRIPTION
## Purpose 

When two videos occur with a single line break they clone each other. Outlined here: https://github.com/brianjgeiger/markdown-it-video/issues/27

This clears the way for: https://github.com/CenterForOpenScience/osf.io/pull/8133

Example image:
<img width="1434" alt="screen shot 2018-02-14 at 1 14 58 pm" src="https://user-images.githubusercontent.com/9688518/36224091-7de4e2f8-1194-11e8-99b1-21fb546c289e.png">

## Changes 
Minor one line change.


## Ticket
https://openscience.atlassian.net/browse/PLAT-493