### PR TITLE
[PLAT-493][Gates] Allow project files to be embedded/rendered in the wiki

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,28 @@ Alternately, you could use the url.
 @[prezi](https://prezi.com/prg6t46qgzik/anatomy-of-a-social-powered-customer-service-win/)
 ```
 
+#### OSF
+
+This plugin allows you to use the OSF's Modualar File Renderer or the MFR to embed video or other files
+ into your markdown assuming your page has mfr.js and mfr.css loaded.
+
+```md
+@[osf](kuvg9)
+```
+
+is interpreted as
+
+```html
+<p><div id="randomid" class="mfr mfr-file"></div><script>$(document).ready(function () {new mfr.Render("randomid", "https://mfr.osf.io/render?url=https://osf.io/kuvg9/?action=download%26mode=render");    }); </script></p>
+```
+
+Alternately, you could use the url.
+
+```md
+@[osf](https://mfr.osf.io/render?url=https://osf.io/kuvg9/?action=download)
+```
+
+
 ## Options
 
 ```js

--- a/index.js
+++ b/index.js
@@ -30,6 +30,7 @@ function preziParser(url) {
   return match ? match[1] : url;
 }
 
+// TODO: Write regex for staging and local servers.
 const mfrRegex = /^http(?:s?):\/\/(?:www\.)?mfr\.osf\.io\/render\?url=http(?:s?):\/\/osf\.io\/([a-zA-Z0-9]{1,5})\/\?action=download/;
 function mfrParser(url) {
   const match = url.match(mfrRegex);
@@ -135,7 +136,7 @@ function tokenizeVideo(md, options) {
     const service = md.utils.escapeHtml(tokens[idx].service).toLowerCase();
     var num;
 
-    if (service === 'osf') {
+    if (service === 'osf' && videoID) {
       num = Math.random() * 0x10000;
       return '<div id="' + num + '" class="mfr mfr-file"></div><script>' +
         '$(document).ready(function () {new mfr.Render("' + num + '", "https://mfr.osf.io/' +
@@ -160,7 +161,7 @@ const defaults = {
   vimeo: { width: 500, height: 281 },
   vine: { width: 600, height: 600, embed: 'simple' },
   prezi: { width: 550, height: 400 },
-  osf: { width: '100%', height: '100%' },
+  osf: { width: '100%', height: '100%' }
 };
 
 module.exports = function videoPlugin(md, options) {

--- a/index.js
+++ b/index.js
@@ -123,7 +123,7 @@ function videoUrl(service, videoID, options) {
         'landing_data=bHVZZmNaNDBIWnNjdEVENDRhZDFNZGNIUE43MHdLNWpsdFJLb2ZHanI5N1lQVHkxSHFxazZ0UUNCRHloSXZROHh3PT0&amp;' +
         'landing_sign=1kD6c0N6aYpMUS0wxnQjxzSqZlEB8qNFdxtdjYhwSuI';
     case 'mfr':
-      return "https://mfr.osf.io/render?url=https://mfr.osf.io/" + videoID + "/?action=download"
+      return "https://mfr.osf.io/render?url=https://osf.io/" + videoID + "/?action=download"
     default:
       return service;
   }

--- a/index.js
+++ b/index.js
@@ -36,7 +36,7 @@ function mfrParser(url) {
 }
 
 
-const EMBED_REGEX = /@\[([a-zA-Z].+)]\([\s]*(.*?)[\s]*[)]/g;
+const EMBED_REGEX = /@\[([a-zA-Z].+)]\([\s]*(.*?)[\s]*[)]/im;
 
 function videoEmbed(md, options) {
   function videoReturn(state, silent) {
@@ -51,8 +51,7 @@ function videoEmbed(md, options) {
         state.src.charCodeAt(oldPos + 1) !== 0x5B/* [ */) {
       return false;
     }
-
-    const match = EMBED_REGEX.exec(state.src);
+    const match = EMBED_REGEX.exec(state.src.slice(state.pos, state.src.length));
 
     if (!match || match.length < 3) {
       return false;

--- a/index.js
+++ b/index.js
@@ -133,6 +133,15 @@ function tokenizeVideo(md, options) {
   function tokenizeReturn(tokens, idx) {
     const videoID = md.utils.escapeHtml(tokens[idx].videoID);
     const service = md.utils.escapeHtml(tokens[idx].service).toLowerCase();
+    console.log(service);
+    if(service === 'file'){
+      var num = Math.random() * 0x10000;
+      return '<div id="' + num + '" class="mfr mfr-file"></div><script>' +
+        'new mfr.Render("#' + num + '", "https://mfr.osf.io/render?url=' +
+        'https://osf.io/' + videoID + '/?action=download%26mode=render"); ' +
+      '</script>';
+    }
+
     return videoID === '' ? '' :
       '<div class="embed-responsive embed-responsive-16by9"><iframe class="embed-responsive-item ' +
       service + '-player" type="text/html" width="' + (options[service].width) +
@@ -150,7 +159,7 @@ const defaults = {
   vimeo: { width: 500, height: 281 },
   vine: { width: 600, height: 600, embed: 'simple' },
   prezi: { width: 550, height: 400 },
-  mfr: { width: 550, height: 400 },
+  file: { width: '100%', height: '100%' },
 };
 
 module.exports = function videoPlugin(md, options) {

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 // Process @[vimeo](vimeoVideoID)
 // Process @[vine](vineVideoID)
 // Process @[prezi](preziID)
-// Process @[file](guid)
+// Process @[osf](guid)
 
 const ytRegex = /^.*((youtu.be\/)|(v\/)|(\/u\/\w\/)|(embed\/)|(watch\?))\??v?=?([^#&?]*).*/;
 function youtubeParser(url) {
@@ -29,6 +29,7 @@ function preziParser(url) {
   const match = url.match(preziRegex);
   return match ? match[1] : url;
 }
+
 const mfrRegex = /^http(?:s?):\/\/(?:www\.)?mfr\.osf\.io\/render\?url=http(?:s?):\/\/osf\.io\/([a-zA-Z0-9]{1,5})\/\?action=download/;
 function mfrParser(url) {
   const match = url.match(mfrRegex);
@@ -69,7 +70,7 @@ function videoEmbed(md, options) {
       videoID = vineParser(videoID);
     } else if (serviceLower === 'prezi') {
       videoID = preziParser(videoID);
-    } else if (serviceLower === 'file') {
+    } else if (serviceLower === 'osf') {
       videoID = mfrParser(videoID);
     } else if (!options[serviceLower]) {
       return false;
@@ -121,7 +122,7 @@ function videoUrl(service, videoID, options) {
         '/?bgcolor=ffffff&amp;lock_to_path=0&amp;autoplay=0&amp;autohide_ctrls=0&amp;' +
         'landing_data=bHVZZmNaNDBIWnNjdEVENDRhZDFNZGNIUE43MHdLNWpsdFJLb2ZHanI5N1lQVHkxSHFxazZ0UUNCRHloSXZROHh3PT0&amp;' +
         'landing_sign=1kD6c0N6aYpMUS0wxnQjxzSqZlEB8qNFdxtdjYhwSuI';
-    case 'file':
+    case 'osf':
       return "https://mfr.osf.io/render?url=https://osf.io/" + videoID + "/?action=download"
     default:
       return service;
@@ -134,7 +135,7 @@ function tokenizeVideo(md, options) {
     const service = md.utils.escapeHtml(tokens[idx].service).toLowerCase();
     var num;
 
-    if (service === 'file') {
+    if (service === 'osf') {
       num = Math.random() * 0x10000;
       return '<div id="' + num + '" class="mfr mfr-file"></div><script>' +
         '$(document).ready(function () {new mfr.Render("' + num + '", "https://mfr.osf.io/' +
@@ -159,7 +160,7 @@ const defaults = {
   vimeo: { width: 500, height: 281 },
   vine: { width: 600, height: 600, embed: 'simple' },
   prezi: { width: 550, height: 400 },
-  file: { width: '100%', height: '100%' },
+  osf: { width: '100%', height: '100%' },
 };
 
 module.exports = function videoPlugin(md, options) {

--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ function preziParser(url) {
 }
 const mfrRegex = /^http(?:s?):\/\/(?:www\.)?mfr\.osf\.io\/render\?url=http(?:s?):\/\/(?:www\.)?mfr\.osf\.io\/([a-zA-Z0-9]{1,5})\/\?action=download%26mode=render/;
 function mfrParser(url) {
-  const match = url.exec(mfrRegex);
+  const match = url.match(mfrRegex);
   return match[1];
 }
 

--- a/index.js
+++ b/index.js
@@ -124,7 +124,7 @@ function videoUrl(service, videoID, options) {
         'landing_data=bHVZZmNaNDBIWnNjdEVENDRhZDFNZGNIUE43MHdLNWpsdFJLb2ZHanI5N1lQVHkxSHFxazZ0UUNCRHloSXZROHh3PT0&amp;' +
         'landing_sign=1kD6c0N6aYpMUS0wxnQjxzSqZlEB8qNFdxtdjYhwSuI';
     case 'osf':
-      return "https://mfr.osf.io/render?url=https://osf.io/" + videoID + "/?action=download"
+      return 'https://mfr.osf.io/render?url=https://osf.io/' + videoID + '/?action=download';
     default:
       return service;
   }
@@ -161,7 +161,7 @@ const defaults = {
   vimeo: { width: 500, height: 281 },
   vine: { width: 600, height: 600, embed: 'simple' },
   prezi: { width: 550, height: 400 },
-  osf: { width: '100%', height: '100%' }
+  osf: { width: '100%', height: '100%' },
 };
 
 module.exports = function videoPlugin(md, options) {

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 // Process @[vimeo](vimeoVideoID)
 // Process @[vine](vineVideoID)
 // Process @[prezi](preziID)
-// Process @[mfr](guid)
+// Process @[file](guid)
 
 const ytRegex = /^.*((youtu.be\/)|(v\/)|(\/u\/\w\/)|(embed\/)|(watch\?))\??v?=?([^#&?]*).*/;
 function youtubeParser(url) {
@@ -36,7 +36,7 @@ function mfrParser(url) {
 }
 
 
-const EMBED_REGEX = /@\[([a-zA-Z].+)]\([\s]*(.*?)[\s]*[)]/im;
+const EMBED_REGEX = /@\[([a-zA-Z].+)]\([\s]*(.*?)[\s]*[)]/g;
 
 function videoEmbed(md, options) {
   function videoReturn(state, silent) {
@@ -133,13 +133,14 @@ function tokenizeVideo(md, options) {
   function tokenizeReturn(tokens, idx) {
     const videoID = md.utils.escapeHtml(tokens[idx].videoID);
     const service = md.utils.escapeHtml(tokens[idx].service).toLowerCase();
-    console.log(service);
-    if(service === 'file'){
-      var num = Math.random() * 0x10000;
+    var num;
+
+    if (service === 'file') {
+      num = Math.random() * 0x10000;
       return '<div id="' + num + '" class="mfr mfr-file"></div><script>' +
-        'new mfr.Render("#' + num + '", "https://mfr.osf.io/render?url=' +
-        'https://osf.io/' + videoID + '/?action=download%26mode=render"); ' +
-      '</script>';
+        '$(document).ready(function () {new mfr.Render("' + num + '", "https://mfr.osf.io/' +
+        'render?url=https://osf.io/' + videoID + '/?action=download%26mode=render");' +
+        '    }); </script>';
     }
 
     return videoID === '' ? '' :

--- a/index.js
+++ b/index.js
@@ -29,10 +29,10 @@ function preziParser(url) {
   const match = url.match(preziRegex);
   return match ? match[1] : url;
 }
-const mfrRegex = /^http(?:s?):\/\/(?:www\.)?mfr\.osf\.io\/render\?url=http(?:s?):\/\/(?:www\.)?mfr\.osf\.io\/([a-zA-Z0-9]{1,5})\/\?action=download%26mode=render/;
+const mfrRegex = /^http(?:s?):\/\/(?:www\.)?mfr\.osf\.io\/render\?url=http(?:s?):\/\/osf\.io\/([a-zA-Z0-9]{1,5})\/\?action=download/;
 function mfrParser(url) {
   const match = url.match(mfrRegex);
-  return match[1];
+  return match ? match[1] : url;
 }
 
 
@@ -123,7 +123,7 @@ function videoUrl(service, videoID, options) {
         'landing_data=bHVZZmNaNDBIWnNjdEVENDRhZDFNZGNIUE43MHdLNWpsdFJLb2ZHanI5N1lQVHkxSHFxazZ0UUNCRHloSXZROHh3PT0&amp;' +
         'landing_sign=1kD6c0N6aYpMUS0wxnQjxzSqZlEB8qNFdxtdjYhwSuI';
     case 'mfr':
-      return "https://mfr.osf.io/render?url=https://mfr.osf.io/" + videoID + "/?action=download%26mode=render"
+      return "https://mfr.osf.io/render?url=https://mfr.osf.io/" + videoID + "/?action=download"
     default:
       return service;
   }
@@ -150,6 +150,7 @@ const defaults = {
   vimeo: { width: 500, height: 281 },
   vine: { width: 600, height: 600, embed: 'simple' },
   prezi: { width: 550, height: 400 },
+  mfr: { width: 550, height: 400 },
 };
 
 module.exports = function videoPlugin(md, options) {

--- a/index.js
+++ b/index.js
@@ -70,7 +70,7 @@ function videoEmbed(md, options) {
       videoID = vineParser(videoID);
     } else if (serviceLower === 'prezi') {
       videoID = preziParser(videoID);
-    } else if (serviceLower === 'mfr') {
+    } else if (serviceLower === 'file') {
       videoID = mfrParser(videoID);
     } else if (!options[serviceLower]) {
       return false;

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@
 // Process @[vimeo](vimeoVideoID)
 // Process @[vine](vineVideoID)
 // Process @[prezi](preziID)
+// Process @[mfr](guid)
 
 const ytRegex = /^.*((youtu.be\/)|(v\/)|(\/u\/\w\/)|(embed\/)|(watch\?))\??v?=?([^#&?]*).*/;
 function youtubeParser(url) {
@@ -28,6 +29,12 @@ function preziParser(url) {
   const match = url.match(preziRegex);
   return match ? match[1] : url;
 }
+const mfrRegex = /^http(?:s?):\/\/(?:www\.)?mfr\.osf\.io\/render\?url=http(?:s?):\/\/(?:www\.)?mfr\.osf\.io\/([a-zA-Z0-9]{1,5})\/\?action=download%26mode=render/;
+function mfrParser(url) {
+  const match = url.exec(mfrRegex);
+  return match[1];
+}
+
 
 const EMBED_REGEX = /@\[([a-zA-Z].+)]\([\s]*(.*?)[\s]*[)]/im;
 
@@ -63,6 +70,8 @@ function videoEmbed(md, options) {
       videoID = vineParser(videoID);
     } else if (serviceLower === 'prezi') {
       videoID = preziParser(videoID);
+    } else if (serviceLower === 'mfr') {
+      videoID = mfrParser(videoID);
     } else if (!options[serviceLower]) {
       return false;
     }
@@ -113,6 +122,8 @@ function videoUrl(service, videoID, options) {
         '/?bgcolor=ffffff&amp;lock_to_path=0&amp;autoplay=0&amp;autohide_ctrls=0&amp;' +
         'landing_data=bHVZZmNaNDBIWnNjdEVENDRhZDFNZGNIUE43MHdLNWpsdFJLb2ZHanI5N1lQVHkxSHFxazZ0UUNCRHloSXZROHh3PT0&amp;' +
         'landing_sign=1kD6c0N6aYpMUS0wxnQjxzSqZlEB8qNFdxtdjYhwSuI';
+    case 'mfr':
+      return "https://mfr.osf.io/render?url=https://mfr.osf.io/" + videoID + "/?action=download%26mode=render"
     default:
       return service;
   }

--- a/index.js
+++ b/index.js
@@ -122,7 +122,7 @@ function videoUrl(service, videoID, options) {
         '/?bgcolor=ffffff&amp;lock_to_path=0&amp;autoplay=0&amp;autohide_ctrls=0&amp;' +
         'landing_data=bHVZZmNaNDBIWnNjdEVENDRhZDFNZGNIUE43MHdLNWpsdFJLb2ZHanI5N1lQVHkxSHFxazZ0UUNCRHloSXZROHh3PT0&amp;' +
         'landing_sign=1kD6c0N6aYpMUS0wxnQjxzSqZlEB8qNFdxtdjYhwSuI';
-    case 'mfr':
+    case 'file':
       return "https://mfr.osf.io/render?url=https://osf.io/" + videoID + "/?action=download"
     default:
       return service;

--- a/test/test.js
+++ b/test/test.js
@@ -1,12 +1,13 @@
+/* eslint func-names: ["error", "never"] */
 var path = require('path');
 var generate = require('markdown-it-testgen');
 var assert = require('assert');
 
-var getMfrId = function(html) {
+function getMfrId(html) {
   return html.split('"')[1];
 }
 
-describe('markdown-it-video', function requireMarkdownIt() {
+describe('markdown-it-video', function () {
   var md = require('markdown-it')({
     html: true,
     linkify: true,
@@ -17,7 +18,7 @@ describe('markdown-it-video', function requireMarkdownIt() {
 
 // Because the mfr iframe requires a random id these tests cannont be part of
 // the markdown-it-testgen fixture
-describe('markdown-it-mfr', function requireMarkdownIt() {
+describe('markdown-it-mfr', function () {
   var md = require('markdown-it')({
     html: true,
     linkify: true,

--- a/test/test.js
+++ b/test/test.js
@@ -1,5 +1,10 @@
 var path = require('path');
 var generate = require('markdown-it-testgen');
+var assert = require('assert');
+
+var getMfrId = function(html) {
+  return html.split('"')[1];
+}
 
 describe('markdown-it-video', function requireMarkdownIt() {
   var md = require('markdown-it')({
@@ -8,4 +13,64 @@ describe('markdown-it-video', function requireMarkdownIt() {
     typography: true,
   }).use(require('../'));
   generate(path.join(__dirname, 'fixtures/video.txt'), md);
+});
+
+// Because the mfr iframe requires a random id these tests cannont be part of
+// the markdown-it-testgen fixture
+describe('markdown-it-mfr', function requireMarkdownIt() {
+  var md = require('markdown-it')({
+    html: true,
+    linkify: true,
+    typography: true,
+  }).use(require('../'));
+  var renderedHtml;
+  var id;
+
+  it('make sure normal iframe generates properly when empty', function () {
+    renderedHtml = md.render('@[osf]()');
+    id = getMfrId(renderedHtml);
+    assert.equal(renderedHtml, '<p></p>\n');
+  });
+
+  it('make sure normal iframe generates properly with guid', function () {
+    renderedHtml = md.render('@[osf](xxxxx)');
+    id = getMfrId(renderedHtml);
+    assert.equal(renderedHtml, '<p><div id="' + id + '" class="mfr mfr-file"></div><script>$(document).ready(function () {new mfr.Render("' + id + '", "https://mfr.osf.io/render?url=https://osf.io/xxxxx/?action=download%26mode=render");    }); </script></p>\n');
+  });
+
+  it('make sure normal iframe generates properly with guid and line break', function () {
+    renderedHtml = md.render('@[osf](xxxxx\n)');
+    id = getMfrId(renderedHtml);
+    assert.equal(renderedHtml, '<p><div id="' + id + '" class="mfr mfr-file"></div><script>$(document).ready(function () {new mfr.Render("' + id + '", "https://mfr.osf.io/render?url=https://osf.io/xxxxx/?action=download%26mode=render");    }); </script></p>\n');
+  });
+
+  it('make sure normal iframe generates properly with guid and extra space', function () {
+    renderedHtml = md.render('@[osf](xxxxx )');
+    id = getMfrId(renderedHtml);
+    assert.equal(renderedHtml, '<p><div id="' + id + '" class="mfr mfr-file"></div><script>$(document).ready(function () {new mfr.Render("' + id + '", "https://mfr.osf.io/render?url=https://osf.io/xxxxx/?action=download%26mode=render");    }); </script></p>\n');
+  });
+
+  it('make sure normal iframe generates properly with guid and two extra spaces', function () {
+    renderedHtml = md.render('@[osf]( xxxxx )');
+    id = getMfrId(renderedHtml);
+    assert.equal(renderedHtml, '<p><div id="' + id + '" class="mfr mfr-file"></div><script>$(document).ready(function () {new mfr.Render("' + id + '", "https://mfr.osf.io/render?url=https://osf.io/xxxxx/?action=download%26mode=render");    }); </script></p>\n');
+  });
+
+  it('make sure normal iframe generates properly with link', function () {
+    renderedHtml = md.render('@[osf](https://mfr.osf.io/render?url=https://osf.io/xxxxx/?action=download%26mode=render)');
+    id = getMfrId(renderedHtml);
+    assert.equal(renderedHtml, '<p><div id="' + id + '" class="mfr mfr-file"></div><script>$(document).ready(function () {new mfr.Render("' + id + '", "https://mfr.osf.io/render?url=https://osf.io/xxxxx/?action=download%26mode=render");    }); </script></p>\n');
+  });
+
+  it('make sure normal iframe generates properly with link and extra space', function () {
+    renderedHtml = md.render('@[osf](https://mfr.osf.io/render?url=https://osf.io/xxxxx/?action=download%26mode=render )');
+    id = getMfrId(renderedHtml);
+    assert.equal(renderedHtml, '<p><div id="' + id + '" class="mfr mfr-file"></div><script>$(document).ready(function () {new mfr.Render("' + id + '", "https://mfr.osf.io/render?url=https://osf.io/xxxxx/?action=download%26mode=render");    }); </script></p>\n');
+  });
+
+  it('make sure normal iframe generates properly with link and two extra spaces', function () {
+    renderedHtml = md.render('@[osf](https://mfr.osf.io/render?url=https://osf.io/xxxxx/?action=download%26mode=render )');
+    id = getMfrId(renderedHtml);
+    assert.equal(renderedHtml, '<p><div id="' + id + '" class="mfr mfr-file"></div><script>$(document).ready(function () {new mfr.Render("' + id + '", "https://mfr.osf.io/render?url=https://osf.io/xxxxx/?action=download%26mode=render");    }); </script></p>\n');
+  });
 });


### PR DESCRIPTION
## Purpose 

Allows files hosted on the OSF to be rendered via the MFR and embed into the wiki markdown.

## Changes

- Adds an mfr service to the the other renderers.
- Adds tests to the test.js file*.
- Adds doc info to the readme.

* These tests can't be done via markdown-it-testgen because they require a random id which markdown-it-testgen can't handle.

## Side Effects

None that I know of.

## QA Notes

See https://github.com/CenterForOpenScience/osf.io/pull/8133

## Ticket

https://openscience.atlassian.net/browse/PLAT-493