### PR TITLE
[PLAT-709] allow for @[osf] test urls

### DIFF
--- a/index.js
+++ b/index.js
@@ -135,22 +135,21 @@ function tokenizeVideo(md, options) {
   function tokenizeReturn(tokens, idx) {
     const videoID = md.utils.escapeHtml(tokens[idx].videoID);
     const service = md.utils.escapeHtml(tokens[idx].service).toLowerCase();
+    var checkUrl = /http(?:s?):\/\/(?:www\.)?[a-zA-Z0-9-:.]{1,}\/render(?:\/)?[a-zA-Z0-9.&;?=:%]{1,}url=http(?:s?):\/\/[a-zA-Z0-9 -:.]{1,}\/[a-zA-Z0-9]{1,5}\/\?[a-zA-Z0-9.=:%]{1,}/;
     var num;
 
     if (service === 'osf' && videoID) {
       num = Math.random() * 0x10000;
-      var checkUrl = /http(?:s?):\/\/(?:www\.)?[a-zA-Z0-9-:.]{1,}\/render(?:\/)?[a-zA-Z0-9.&;?=:%]{1,}url=http(?:s?):\/\/[a-zA-Z0-9 -:.]{1,}\/[a-zA-Z0-9]{1,5}\/\?[a-zA-Z0-9.=:%]{1,}/
 
       if (videoID.match(checkUrl)) {
         return '<div id="' + num + '" class="mfr mfr-file"></div><script>' +
           '$(document).ready(function () {new mfr.Render("' + num + '", "' + videoID + '");' +
           '    }); </script>';
-      } else {
-        return '<div id="' + num + '" class="mfr mfr-file"></div><script>' +
-          '$(document).ready(function () {new mfr.Render("' + num + '", "https://mfr.osf.io/' +
-          'render?url=https://osf.io/' + videoID + '/?action=download%26mode=render");' +
-          '    }); </script>';
       }
+      return '<div id="' + num + '" class="mfr mfr-file"></div><script>' +
+        '$(document).ready(function () {new mfr.Render("' + num + '", "https://mfr.osf.io/' +
+        'render?url=https://osf.io/' + videoID + '/?action=download%26mode=render");' +
+        '    }); </script>';
     }
 
     return videoID === '' ? '' :

--- a/index.js
+++ b/index.js
@@ -139,10 +139,18 @@ function tokenizeVideo(md, options) {
 
     if (service === 'osf' && videoID) {
       num = Math.random() * 0x10000;
-      return '<div id="' + num + '" class="mfr mfr-file"></div><script>' +
-        '$(document).ready(function () {new mfr.Render("' + num + '", "https://mfr.osf.io/' +
-        'render?url=https://osf.io/' + videoID + '/?action=download%26mode=render");' +
-        '    }); </script>';
+      var check_url = /^http(?:s?):\/\/(?:www\.)?[a-zA-Z0-9-:.]{1,}\/render\?url=http(?:s?):\/\/[a-zA-Z0-9 -:.]{1,}\/[a-zA-Z0-9]{1,5}\/\?[a-zA-Z0-=%9]{1,}/
+      // Allows access to 
+      if (videoID.match(check_url)) {
+        return '<div id="' + num + '" class="mfr mfr-file"></div><script>' +
+          '$(document).ready(function () {new mfr.Render("' + num + '", "' + videoID + '");' +
+          '    }); </script>';
+      } else {
+        return '<div id="' + num + '" class="mfr mfr-file"></div><script>' +
+          '$(document).ready(function () {new mfr.Render("' + num + '", "https://mfr.osf.io/' +
+          'render?url=https://osf.io/' + videoID + '/?action=download%26mode=render");' +
+          '    }); </script>';
+      }
     }
 
     return videoID === '' ? '' :

--- a/index.js
+++ b/index.js
@@ -139,8 +139,8 @@ function tokenizeVideo(md, options) {
 
     if (service === 'osf' && videoID) {
       num = Math.random() * 0x10000;
-      var check_url = /^http(?:s?):\/\/(?:www\.)?[a-zA-Z0-9-:.]{1,}\/render\?url=http(?:s?):\/\/[a-zA-Z0-9 -:.]{1,}\/[a-zA-Z0-9]{1,5}\/\?[a-zA-Z0-=%9]{1,}/
-      // Allows access to 
+      var check_url = /http(?:s?):\/\/(?:www\.)?[a-zA-Z0-9-:.]{1,}\/render(?:\/)?[a-zA-Z0-9.&;?=:%]{1,}url=http(?:s?):\/\/[a-zA-Z0-9 -:.]{1,}\/[a-zA-Z0-9]{1,5}\/\?[a-zA-Z0-9.=:%]{1,}/
+
       if (videoID.match(check_url)) {
         return '<div id="' + num + '" class="mfr mfr-file"></div><script>' +
           '$(document).ready(function () {new mfr.Render("' + num + '", "' + videoID + '");' +

--- a/index.js
+++ b/index.js
@@ -139,9 +139,9 @@ function tokenizeVideo(md, options) {
 
     if (service === 'osf' && videoID) {
       num = Math.random() * 0x10000;
-      var check_url = /http(?:s?):\/\/(?:www\.)?[a-zA-Z0-9-:.]{1,}\/render(?:\/)?[a-zA-Z0-9.&;?=:%]{1,}url=http(?:s?):\/\/[a-zA-Z0-9 -:.]{1,}\/[a-zA-Z0-9]{1,5}\/\?[a-zA-Z0-9.=:%]{1,}/
+      var checkUrl = /http(?:s?):\/\/(?:www\.)?[a-zA-Z0-9-:.]{1,}\/render(?:\/)?[a-zA-Z0-9.&;?=:%]{1,}url=http(?:s?):\/\/[a-zA-Z0-9 -:.]{1,}\/[a-zA-Z0-9]{1,5}\/\?[a-zA-Z0-9.=:%]{1,}/
 
-      if (videoID.match(check_url)) {
+      if (videoID.match(checkUrl)) {
         return '<div id="' + num + '" class="mfr mfr-file"></div><script>' +
           '$(document).ready(function () {new mfr.Render("' + num + '", "' + videoID + '");' +
           '    }); </script>';

--- a/test/test.js
+++ b/test/test.js
@@ -74,4 +74,17 @@ describe('markdown-it-mfr', function () {
     id = getMfrId(renderedHtml);
     assert.equal(renderedHtml, '<p><div id="' + id + '" class="mfr mfr-file"></div><script>$(document).ready(function () {new mfr.Render("' + id + '", "https://mfr.osf.io/render?url=https://osf.io/xxxxx/?action=download%26mode=render");    }); </script></p>\n');
   });
+
+  it('make sure normal iframe generates properly with link to staging', function () {
+    renderedHtml = md.render('@[osf](https://mfr-staging3.osf.io/render?url=https://staging3.osf.io/xxxxx/?action=download%26mode=render)');
+    id = getMfrId(renderedHtml);
+    assert.equal(renderedHtml, '<p><div id="' + id + '" class="mfr mfr-file"></div><script>$(document).ready(function () {new mfr.Render("' + id + '", "https://mfr-staging3.osf.io/render?url=https://staging3.osf.io/xxxxx/?action=download%26mode=render");    }); </script></p>\n');
+  });
+
+  it('make sure normal iframe generates properly with link to local', function () {
+    renderedHtml = md.render('@[osf](https://localhost:7778/render?url=https://localhost:5000/xxxxx/?action=download%26mode=render)');
+    id = getMfrId(renderedHtml);
+    assert.equal(renderedHtml, '<p><div id="' + id + '" class="mfr mfr-file"></div><script>$(document).ready(function () {new mfr.Render("' + id + '", "https://localhost:7778/render?url=https://localhost:5000/xxxxx/?action=download%26mode=render");    }); </script></p>\n');
+  });
+
 });

--- a/test/test.js
+++ b/test/test.js
@@ -92,5 +92,4 @@ describe('markdown-it-mfr', function () {
     id = getMfrId(renderedHtml);
     assert.equal(renderedHtml, '<p><div id="' + id + '" class="mfr mfr-file"></div><script>$(document).ready(function () {new mfr.Render("' + id + '", "http://localhost:7778/render?mode=render&amp;url=http://192.168.168.167:5000/y98tn/?action=download%26mode=render%26direct");    }); </script></p>\n');
   });
-
 });

--- a/test/test.js
+++ b/test/test.js
@@ -87,4 +87,10 @@ describe('markdown-it-mfr', function () {
     assert.equal(renderedHtml, '<p><div id="' + id + '" class="mfr mfr-file"></div><script>$(document).ready(function () {new mfr.Render("' + id + '", "https://localhost:7778/render?url=https://localhost:5000/xxxxx/?action=download%26mode=render");    }); </script></p>\n');
   });
 
+  it('make sure normal iframe generates properly with link to local ip', function () {
+    renderedHtml = md.render('@[osf](http://localhost:7778/render?mode=render&url=http://192.168.168.167:5000/y98tn/?action=download%26mode=render%26direct)');
+    id = getMfrId(renderedHtml);
+    assert.equal(renderedHtml, '<p><div id="' + id + '" class="mfr mfr-file"></div><script>$(document).ready(function () {new mfr.Render("' + id + '", "http://localhost:7778/render?mode=render&amp;url=http://192.168.168.167:5000/y98tn/?action=download%26mode=render%26direct");    }); </script></p>\n');
+  });
+
 });


### PR DESCRIPTION
## Purpose

Currently @[osf] wiki markdown tags only point to prod, this is not desirable for QA. This PR gives the markdown a bit of flexibility so QA/developers can access the staging/local servers by putting their url as the video id so while `@[osf](guid1)` will still always point to prod `@[osf](localhost:7778/render?mode=render&url=http://192.168.168.167:5000/y98tn/?action=download%26mode=render%26direct)` or `@[osf](http://mfr-staging3.io/render?mode=render&url=http://192.168.168.167:5000/y98tn/?action=download%26mode=render%26direct)` will validly point to 

## Changes

- Modifies regex and return statment to allow for raw urls.

## Side Effects

None that I know of.

## QA Notes

For the exact MFR link, use the iframe or share button link.

## Ticket
This is going to be required to test [PLAT-709](https://openscience.atlassian.net/projects/PLAT/issues/PLAT-709)