### PR TITLE
Fix/Embedded Video + Markdown infinite loops [PLAT-974]

### DIFF
--- a/index.js
+++ b/index.js
@@ -92,7 +92,6 @@ function videoEmbed(md, options) {
     //
     if (!silent) {
       theState.pos = serviceStart;
-      theState.posMax = serviceEnd;
       theState.service = theState.src.slice(serviceStart, serviceEnd);
       const newState = new theState.md.inline.State(service, theState.md, theState.env, []);
       newState.md.inline.tokenize(newState);
@@ -104,7 +103,6 @@ function videoEmbed(md, options) {
     }
 
     theState.pos += theState.src.indexOf(')', theState.pos);
-    theState.posMax = theState.tokens.length;
     return true;
   }
 

--- a/test/fixtures/video.txt
+++ b/test/fixtures/video.txt
@@ -341,3 +341,11 @@ Coverage. Line Breaks
 <p><div class="embed-responsive embed-responsive-16by9"><iframe class="embed-responsive-item vine-player" type="text/html" width="600" height="600" src="https://vine.co/v/MhQ2lvg29Un/embed/simple" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe></div></p>
 <p><div class="embed-responsive embed-responsive-16by9"><iframe class="embed-responsive-item vine-player" type="text/html" width="600" height="600" src="https://vine.co/v/00000000000/embed/simple" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe></div></p>
 .
+
+Coverage. Bug with formatted markdown after embed
+.
+@[youtube](dQw4w9WgXcQ)
+*foo*
+.
+<p><div class="embed-responsive embed-responsive-16by9"><iframe class="embed-responsive-item youtube-player" type="text/html" width="640" height="390" src="https://www.youtube.com/embed/dQw4w9WgXcQ" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe></div><em>foo</em></p>
+.


### PR DESCRIPTION
❗️ Once merged, will need to update `markdown-it-video` requirement in https://github.com/CenterForOpenScience/osf.io/blob/develop/package.json#L53
# Purpose
Embedding a video followed by formatted markdown causes the browser to hang indefinitely.
```
@[osf](pqya4)
*foo*
```

# Changes
- Removed manually setting posMax, instead falling back to the total string length
- Added test for formatted markdown after embedding video (slight modification on @sloria's test, wrapping entire expected html in a paragraph tag.

# After
Video embedded followed by texts in italics
<img width="907" alt="screen shot 2018-07-17 at 12 47 16 pm" src="https://user-images.githubusercontent.com/9755598/42836307-4592d97e-89c0-11e8-8edd-8e60ecf170cd.png">


# Ticket
https://openscience.atlassian.net/browse/PLAT-974