### PR TITLE
Update RegExp - Now works with more URL styles

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,11 +11,11 @@ function youtubeParser(url) {
 }
 
 /* eslint-disable max-len */
-const vimeoRegex = /(?:http:|https:|)\/\/(?:player.|www.)?vimeo\.com\/(?:video\/|embed\/|watch\?\S*v=|v\/)?(\d*)/;
+const vimeoRegex = /(?:http:|https:)?\/\/(?:www\.|player\.)?vimeo.com\/(?:channels\/(?:\w+\/)?|groups\/([^/]*)\/videos\/|album\/(\d+)\/video\/|)(\d+)/;
 /* eslint-enable max-len */
 function vimeoParser(url) {
   const match = url.match(vimeoRegex);
-  return match && typeof match[1] === 'string' ? match[1] : url;
+  return match && typeof match[3] === 'string' ? match[3] : url;
 }
 
 const vineRegex = /^http(?:s?):\/\/(?:www\.)?vine\.co\/v\/([a-zA-Z0-9]{1,13}).*/;

--- a/index.js
+++ b/index.js
@@ -11,11 +11,11 @@ function youtubeParser(url) {
 }
 
 /* eslint-disable max-len */
-const vimeoRegex = /https?:\/\/(?:www\.|player\.)?vimeo.com\/(?:channels\/(?:\w+\/)?|groups\/([^/]*)\/videos\/|album\/(\d+)\/video\/|)(\d+)(?:$|\/|\?)/;
+const vimeoRegex = /(?:http:|https:|)\/\/(?:player.|www.)?vimeo\.com\/(?:video\/|embed\/|watch\?\S*v=|v\/)?(\d*)/;
 /* eslint-enable max-len */
 function vimeoParser(url) {
   const match = url.match(vimeoRegex);
-  return match && typeof match[3] === 'string' ? match[3] : url;
+  return match && typeof match[1] === 'string' ? match[1] : url;
 }
 
 const vineRegex = /^http(?:s?):\/\/(?:www\.)?vine\.co\/v\/([a-zA-Z0-9]{1,13}).*/;

--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ function youtubeParser(url) {
 }
 
 /* eslint-disable max-len */
-const vimeoRegex = /(?:http:|https:)?\/\/(?:www\.|player\.)?vimeo.com\/(?:channels\/(?:\w+\/)?|groups\/([^/]*)\/videos\/|album\/(\d+)\/video\/|)(\d+)/;
+const vimeoRegex = /(?:http:|https:)?\/\/(?:www\.|player\.)?vimeo.com\/(?:channels\/(?:\w+\/)?|groups\/([^/]*)\/videos\/|album\/(\d+)\/video\/|video\/|)(\d+)/;
 /* eslint-enable max-len */
 function vimeoParser(url) {
   const match = url.match(vimeoRegex);


### PR DESCRIPTION
The previous regular expression doesn't work with some URLs
Test RegExp at https://regexr.com/4lrm3. This woks with:
@[vimeo](https://www.vimeo.com/19706846)
@[vimeo](https://vimeo.com/19706846)
@[vimeo](https://player.vimeo.com/video/19706846&jjk)
@[vimeo](https://vimeo.com/341842996?app_id=122963)