### PR TITLE
Added support for youtube embed parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,9 +135,31 @@ Alternately, you could use the url.
 @[osf](https://mfr.osf.io/render?url=https://osf.io/kuvg9/?action=download)
 ```
 
-
 ## Options
 
 ```js
 
 ```
+
+#### YouTube
+
+###### nocookie
+
+Use https://youtube-nocookie.com instead of https://youtube.com for all embeds. This enables 'Privacy Enhanced Mode' as described at the corresponding [Google help page](https://support.google.com/youtube/answer/171780)
+
+###### parameters
+
+This option allows to add/overwrite embed parameters globally.
+Pass an object with parameter/value pairs to change the design and behavior of the YouTube player.
+For a list of valid parameters please refer to the [official documentation](https://developers.google.com/youtube/player_parameters#Parameters).
+
+Example:
+*Start playback at 10 seconds and disable displaying related videos.*
+
+```js
+{
+    rel: 0,
+    start: 10
+}
+```
+

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Alternately, you could use a number of different YouTube URL formats rather than
 @[youtube](http://www.youtube.com/embed/dQw4w9WgXcQ?rel=0)
 @[youtube](http://www.youtube.com/watch?v=dQw4w9WgXcQ)
 @[youtube](http://youtu.be/dQw4w9WgXcQ)
+@[youtube](dQw4w9WgXcQ?rel=0)
 ```
 
 #### Vimeo
@@ -141,13 +142,22 @@ Alternately, you could use the url.
 
 ```
 
-#### YouTube
+### YouTube
 
-###### nocookie
+```js
+youtube: {
+  width: 640,
+  height: 390,
+  nocookie: false,
+  parameters: {}
+}
+```
+
+##### nocookie
 
 Use https://youtube-nocookie.com instead of https://youtube.com for all embeds. This enables 'Privacy Enhanced Mode' as described at the corresponding [Google help page](https://support.google.com/youtube/answer/171780)
 
-###### parameters
+##### parameters
 
 This option allows to add/overwrite embed parameters globally.
 Pass an object with parameter/value pairs to change the design and behavior of the YouTube player.
@@ -162,4 +172,3 @@ Example:
     start: 10
 }
 ```
-

--- a/index.js
+++ b/index.js
@@ -143,7 +143,9 @@ function videoUrl(service, videoID, url, options) {
         let j = 0;
 
         while (timeParts.length > 0) {
-          startTime += Number(timeParts.pop()) * (60 ** j);
+          /* eslint-disable no-restricted-properties */
+          startTime += Number(timeParts.pop()) * Math.pow(60, j);
+          /* eslint-enable no-restricted-properties */
           j += 1;
         }
         parameters.set('start', startTime);

--- a/index.js
+++ b/index.js
@@ -129,8 +129,8 @@ function videoUrl(service, videoID, url, options) {
     case 'youtube': {
       const parameters = extractVideoParameters(url);
       if (options.youtube.parameters) {
-        Object.entries(options.youtube.parameters).forEach(([key, value]) => {
-          parameters.set(key, value);
+        Object.keys(options.youtube.parameters).forEach((key) => {
+          parameters.set(key, options.youtube.parameters[key]);
         });
       }
 

--- a/index.js
+++ b/index.js
@@ -50,7 +50,7 @@ function videoEmbed(md, options) {
     const oldPos = state.pos;
 
     if (state.src.charCodeAt(oldPos) !== 0x40/* @ */ ||
-        state.src.charCodeAt(oldPos + 1) !== 0x5B/* [ */) {
+      state.src.charCodeAt(oldPos + 1) !== 0x5B/* [ */) {
       return false;
     }
 
@@ -99,6 +99,7 @@ function videoEmbed(md, options) {
       token = theState.push('video', '');
       token.videoID = videoID;
       token.service = service;
+      token.url = match[2];
       token.level = theState.level;
     }
 
@@ -109,10 +110,59 @@ function videoEmbed(md, options) {
   return videoReturn;
 }
 
-function videoUrl(service, videoID, options) {
+function extractVideoParameters(url) {
+  const parameterMap = new Map();
+  const params = url.replace(/&amp;/gi, '&').split(/[#?&]/);
+
+  if (params.length > 1) {
+    for (let i = 1; i < params.length; i += 1) {
+      const keyValue = params[i].split('=');
+      if (keyValue.length > 1) parameterMap.set(keyValue[0], keyValue[1]);
+    }
+  }
+
+  return parameterMap;
+}
+
+function videoUrl(service, videoID, url, options) {
   switch (service) {
-    case 'youtube':
-      return 'https://www.youtube.com/embed/' + videoID;
+    case 'youtube': {
+      const parameters = extractVideoParameters(url);
+      if (options.youtube.parameters) {
+        Object.entries(options.youtube.parameters).forEach(([key, value]) => {
+          parameters.set(key, value);
+        });
+      }
+
+      // Start time parameter can have the format t=0m10s or t=<time_in_seconds> in share URLs,
+      // but in embed URLs the parameter must be called 'start' and time must be in seconds
+      const timeParameter = parameters.get('t');
+      if (timeParameter !== undefined) {
+        let startTime = 0;
+        const timeParts = timeParameter.match(/[0-9]+/g);
+        let j = 0;
+
+        while (timeParts.length > 0) {
+          startTime += Number(timeParts.pop()) * (60 ** j);
+          j += 1;
+        }
+        parameters.set('start', startTime);
+        parameters.delete('t');
+      }
+
+      parameters.delete('v');
+      parameters.delete('feature');
+      parameters.delete('origin');
+
+      const parameterArray = Array.from(parameters, p => p.join('='));
+      const parameterPos = videoID.indexOf('?');
+
+      let finalUrl = 'https://www.youtube';
+      if (options.youtube.nocookie || url.indexOf('youtube-nocookie.com') > -1) finalUrl += '-nocookie';
+      finalUrl += '.com/embed/' + (parameterPos > -1 ? videoID.substr(0, parameterPos) : videoID);
+      if (parameterArray.length > 0) finalUrl += '?' + parameterArray.join('&');
+      return finalUrl;
+    }
     case 'vimeo':
       return 'https://player.vimeo.com/video/' + videoID;
     case 'vine':
@@ -154,7 +204,7 @@ function tokenizeVideo(md, options) {
       '<div class="embed-responsive embed-responsive-16by9"><iframe class="embed-responsive-item ' +
       service + '-player" type="text/html" width="' + (options[service].width) +
       '" height="' + (options[service].height) +
-      '" src="' + options.url(service, videoID, options) +
+      '" src="' + options.url(service, videoID, tokens[idx].url, options) +
       '" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe></div>';
   }
 
@@ -163,7 +213,7 @@ function tokenizeVideo(md, options) {
 
 const defaults = {
   url: videoUrl,
-  youtube: { width: 640, height: 390 },
+  youtube: { width: 640, height: 390, nocookie: false },
   vimeo: { width: 500, height: 281 },
   vine: { width: 600, height: 600, embed: 'simple' },
   prezi: { width: 550, height: 400 },

--- a/test/fixtures/video.txt
+++ b/test/fixtures/video.txt
@@ -369,7 +369,7 @@ Coverage. Bug with formatted markdown after embed
 .
 <p><div class="embed-responsive embed-responsive-16by9"><iframe class="embed-responsive-item youtube-player" type="text/html" width="640" height="390" src="https://www.youtube.com/embed/dQw4w9WgXcQ" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe></div><em>foo</em></p>
 .
-Security. HTML in url
+Security. HTML in URL
 .
 @[youtube](<a href="example.com">dQw4w9WgXcQ</a>)
 *foo*

--- a/test/fixtures/video.txt
+++ b/test/fixtures/video.txt
@@ -89,17 +89,27 @@ Coverage. Youtube from URL
 .
 @[youtube](//www.youtube.com/v/0zM3nApSvMg?fs=1&amp;hl=en_US&amp;rel=0)
 .
-<p><div class="embed-responsive embed-responsive-16by9"><iframe class="embed-responsive-item youtube-player" type="text/html" width="640" height="390" src="https://www.youtube.com/embed/0zM3nApSvMg" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe></div></p>
+<p><div class="embed-responsive embed-responsive-16by9"><iframe class="embed-responsive-item youtube-player" type="text/html" width="640" height="390" src="https://www.youtube.com/embed/0zM3nApSvMg?fs=1&hl=en_US&rel=0" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe></div></p>
 .
 .
 @[youtube](//www.youtube.com/watch?v=0zM3nApSvMg#t=0m10s)
 .
-<p><div class="embed-responsive embed-responsive-16by9"><iframe class="embed-responsive-item youtube-player" type="text/html" width="640" height="390" src="https://www.youtube.com/embed/0zM3nApSvMg" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe></div></p>
+<p><div class="embed-responsive embed-responsive-16by9"><iframe class="embed-responsive-item youtube-player" type="text/html" width="640" height="390" src="https://www.youtube.com/embed/0zM3nApSvMg?start=10" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe></div></p>
+.
+.
+@[youtube](//www.youtube.com/watch?v=0zM3nApSvMg#t=10)
+.
+<p><div class="embed-responsive embed-responsive-16by9"><iframe class="embed-responsive-item youtube-player" type="text/html" width="640" height="390" src="https://www.youtube.com/embed/0zM3nApSvMg?start=10" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe></div></p>
 .
 .
 @[youtube](//www.youtube.com/embed/0zM3nApSvMg?rel=0)
 .
-<p><div class="embed-responsive embed-responsive-16by9"><iframe class="embed-responsive-item youtube-player" type="text/html" width="640" height="390" src="https://www.youtube.com/embed/0zM3nApSvMg" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe></div></p>
+<p><div class="embed-responsive embed-responsive-16by9"><iframe class="embed-responsive-item youtube-player" type="text/html" width="640" height="390" src="https://www.youtube.com/embed/0zM3nApSvMg?rel=0" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe></div></p>
+.
+.
+@[youtube](//www.youtube-nocookie.com/embed/0zM3nApSvMg?rel=0)
+.
+<p><div class="embed-responsive embed-responsive-16by9"><iframe class="embed-responsive-item youtube-player" type="text/html" width="640" height="390" src="https://www.youtube-nocookie.com/embed/0zM3nApSvMg?rel=0" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe></div></p>
 .
 .
 @[youtube](//www.youtube.com/watch?v=0zM3nApSvMg)
@@ -110,6 +120,16 @@ Coverage. Youtube from URL
 @[youtube](http://youtu.be/0zM3nApSvMg)
 .
 <p><div class="embed-responsive embed-responsive-16by9"><iframe class="embed-responsive-item youtube-player" type="text/html" width="640" height="390" src="https://www.youtube.com/embed/0zM3nApSvMg" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe></div></p>
+.
+.
+@[youtube](https://www.youtube.com/embed/DBXH9jJRaDk?autoplay=0&fs=0&iv_load_policy=3&showinfo=1&rel=0&cc_load_policy=0&start=0&end=5&origin=https://example.com)
+.
+<p><div class="embed-responsive embed-responsive-16by9"><iframe class="embed-responsive-item youtube-player" type="text/html" width="640" height="390" src="https://www.youtube.com/embed/DBXH9jJRaDk?autoplay=0&fs=0&iv_load_policy=3&showinfo=1&rel=0&cc_load_policy=0&start=0&end=5" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe></div></p>
+.
+.
+@[youtube](KMU0tzLwhbE?rel=0)
+.
+<p><div class="embed-responsive embed-responsive-16by9"><iframe class="embed-responsive-item youtube-player" type="text/html" width="640" height="390" src="https://www.youtube.com/embed/KMU0tzLwhbE?rel=0" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe></div></p>
 .
 
 Coverage. Vimeo from ID
@@ -348,4 +368,11 @@ Coverage. Bug with formatted markdown after embed
 *foo*
 .
 <p><div class="embed-responsive embed-responsive-16by9"><iframe class="embed-responsive-item youtube-player" type="text/html" width="640" height="390" src="https://www.youtube.com/embed/dQw4w9WgXcQ" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe></div><em>foo</em></p>
+.
+Security. HTML in url
+.
+@[youtube](<a href="example.com">dQw4w9WgXcQ</a>)
+*foo*
+.
+<p><div class="embed-responsive embed-responsive-16by9"><iframe class="embed-responsive-item youtube-player" type="text/html" width="640" height="390" src="https://www.youtube.com/embed/&lt;a href=&quot;example.com&quot;&gt;dQw4w9WgXcQ&lt;/a&gt;" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe></div><em>foo</em></p>
 .

--- a/test/test.js
+++ b/test/test.js
@@ -16,6 +16,36 @@ describe('markdown-it-video', function () {
   generate(path.join(__dirname, 'fixtures/video.txt'), md);
 });
 
+describe('markdown-it-video: options', function () {
+  var md = require('markdown-it')({
+    html: true,
+    linkify: true,
+    typography: true,
+  }).use(require('../'), {
+    youtube: {
+      width: 640,
+      height: 390,
+      nocookie: true,
+      parameters: {
+        rel: 0,
+        fs: 0,
+        autoplay: 0,
+      },
+    },
+  });
+  var renderedHtml;
+
+  it('normal to nocookie', function () {
+    renderedHtml = md.render('@[youtube](youtube.com/v/0zM3nApSvMg)');
+    assert.equal(renderedHtml, '<p><div class="embed-responsive embed-responsive-16by9"><iframe class="embed-responsive-item youtube-player" type="text/html" width="640" height="390" src="https://www.youtube-nocookie.com/embed/0zM3nApSvMg?rel=0&fs=0&autoplay=0" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe></div></p>\n');
+  });
+
+  it('overwrite parameter', function () {
+    renderedHtml = md.render('@[youtube](youtube.com/embed/0zM3nApSvMg?autoplay=1&rel=0)');
+    assert.equal(renderedHtml, '<p><div class="embed-responsive embed-responsive-16by9"><iframe class="embed-responsive-item youtube-player" type="text/html" width="640" height="390" src="https://www.youtube-nocookie.com/embed/0zM3nApSvMg?autoplay=0&rel=0&fs=0" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe></div></p>\n');
+  });
+});
+
 // Because the mfr iframe requires a random id these tests cannont be part of
 // the markdown-it-testgen fixture
 describe('markdown-it-mfr', function () {


### PR DESCRIPTION
This change adds support for URL parameters for YouTube embeds. 
Instead of only extracting the video ID, all parameters are now parsed and reflected in the final embed HTML.

As proposed in #33, this is not limited to full URLs, the short format `@[youtube](KMU0tzLwhbE?rel=0)` works as well.

It is also possible to globally overwrite certain parameters, e.g. to prevent autoplay or looping, by passing a map of default values as part of the options object.

For more details on the new features take a look at the updated readme and test cases.