### PR TITLE
Update RegExp - Now works with more URL styles, and tests

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,11 +11,11 @@ function youtubeParser(url) {
 }
 
 /* eslint-disable max-len */
-const vimeoRegex = /(?:http:|https:|)\/\/(?:player.|www.)?vimeo\.com\/(?:video\/|embed\/|watch\?\S*v=|v\/)?(\d*)/;
+const vimeoRegex = /(?:http:|https:)?\/\/(?:www\.|player\.)?vimeo.com\/(?:channels\/(?:\w+\/)?|groups\/([^/]*)\/videos\/|album\/(\d+)\/video\/|)(\d+)/;
 /* eslint-enable max-len */
 function vimeoParser(url) {
   const match = url.match(vimeoRegex);
-  return match && typeof match[1] === 'string' ? match[1] : url;
+  return match && typeof match[3] === 'string' ? match[3] : url;
 }
 
 const vineRegex = /^http(?:s?):\/\/(?:www\.)?vine\.co\/v\/([a-zA-Z0-9]{1,13}).*/;

--- a/index.js
+++ b/index.js
@@ -11,11 +11,11 @@ function youtubeParser(url) {
 }
 
 /* eslint-disable max-len */
-const vimeoRegex = /https?:\/\/(?:www\.|player\.)?vimeo.com\/(?:channels\/(?:\w+\/)?|groups\/([^/]*)\/videos\/|album\/(\d+)\/video\/|)(\d+)(?:$|\/|\?)/;
+const vimeoRegex = /(?:http:|https:|)\/\/(?:player.|www.)?vimeo\.com\/(?:video\/|embed\/|watch\?\S*v=|v\/)?(\d*)/;
 /* eslint-enable max-len */
 function vimeoParser(url) {
   const match = url.match(vimeoRegex);
-  return match && typeof match[3] === 'string' ? match[3] : url;
+  return match && typeof match[1] === 'string' ? match[1] : url;
 }
 
 const vineRegex = /^http(?:s?):\/\/(?:www\.)?vine\.co\/v\/([a-zA-Z0-9]{1,13}).*/;

--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ function youtubeParser(url) {
 }
 
 /* eslint-disable max-len */
-const vimeoRegex = /(?:http:|https:)?\/\/(?:www\.|player\.)?vimeo.com\/(?:channels\/(?:\w+\/)?|groups\/([^/]*)\/videos\/|album\/(\d+)\/video\/|)(\d+)/;
+const vimeoRegex = /(?:http:|https:)?\/\/(?:www\.|player\.)?vimeo.com\/(?:channels\/(?:\w+\/)?|groups\/([^/]*)\/videos\/|album\/(\d+)\/video\/|video\/|)(\d+)/;
 /* eslint-enable max-len */
 function vimeoParser(url) {
   const match = url.match(vimeoRegex);

--- a/test/fixtures/video.txt
+++ b/test/fixtures/video.txt
@@ -223,6 +223,8 @@ Coverage. Vimeo from URL
 .
 <p><div class="embed-responsive embed-responsive-16by9"><iframe class="embed-responsive-item vimeo-player" type="text/html" width="500" height="281" src="https://player.vimeo.com/video/119932781" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe></div></p>
 .
+
+Coverage. Vine
 .
 @[vine](https://vine.co/v/MhQ2lvg29Un/embed)
 .

--- a/test/fixtures/video.txt
+++ b/test/fixtures/video.txt
@@ -181,11 +181,6 @@ x
 .
 <p>@[(vimeo]</p>
 .
-.
-@[toc]()
-.
-<p>@<a href="">toc</a></p>
-.
 
 Coverage. Vimeo from URL
 .
@@ -315,11 +310,6 @@ x
 @[(prezi]
 .
 <p>@[(prezi]</p>
-.
-.
-@[toc]()
-.
-<p>@<a href="">toc</a></p>
 .
 
 Coverage. Prezi from URL

--- a/test/fixtures/video.txt
+++ b/test/fixtures/video.txt
@@ -162,6 +162,11 @@ x
 <p><div class="embed-responsive embed-responsive-16by9"><iframe class="embed-responsive-item vimeo-player" type="text/html" width="500" height="281" src="https://player.vimeo.com/video/x" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe></div></p>
 .
 .
+@[vimeo](123)
+.
+<p><div class="embed-responsive embed-responsive-16by9"><iframe class="embed-responsive-item vimeo-player" type="text/html" width="500" height="281" src="https://player.vimeo.com/video/123" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe></div></p>
+.
+.
 @[]vimeo()
 .
 <p>@[]vimeo()</p>
@@ -180,6 +185,13 @@ x
 @[(vimeo]
 .
 <p>@[(vimeo]</p>
+.
+
+Include text after digits in videoID if only videoID is specified
+.
+@[vimeo](1x)
+.
+<p><div class="embed-responsive embed-responsive-16by9"><iframe class="embed-responsive-item vimeo-player" type="text/html" width="500" height="281" src="https://player.vimeo.com/video/1x" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe></div></p>
 .
 
 Coverage. Vimeo from URL
@@ -204,7 +216,17 @@ Coverage. Vimeo from URL
 <p><div class="embed-responsive embed-responsive-16by9"><iframe class="embed-responsive-item vimeo-player" type="text/html" width="500" height="281" src="https://player.vimeo.com/video/119932781" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe></div></p>
 .
 .
+@[vimeo](http://vimeo.com/channels/119932781)
+.
+<p><div class="embed-responsive embed-responsive-16by9"><iframe class="embed-responsive-item vimeo-player" type="text/html" width="500" height="281" src="https://player.vimeo.com/video/119932781" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe></div></p>
+.
+.
 @[vimeo](https://vimeo.com/groups/staffpicks/videos/119932781)
+.
+<p><div class="embed-responsive embed-responsive-16by9"><iframe class="embed-responsive-item vimeo-player" type="text/html" width="500" height="281" src="https://player.vimeo.com/video/119932781" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe></div></p>
+.
+.
+@[vimeo](https://vimeo.com/groups//videos/119932781)
 .
 <p><div class="embed-responsive embed-responsive-16by9"><iframe class="embed-responsive-item vimeo-player" type="text/html" width="500" height="281" src="https://player.vimeo.com/video/119932781" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe></div></p>
 .
@@ -222,6 +244,52 @@ Coverage. Vimeo from URL
 @[vimeo](http://player.vimeo.com/119932781)
 .
 <p><div class="embed-responsive embed-responsive-16by9"><iframe class="embed-responsive-item vimeo-player" type="text/html" width="500" height="281" src="https://player.vimeo.com/video/119932781" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe></div></p>
+.
+.
+@[vimeo](https://player.vimeo.com/video/19706846)
+.
+<p><div class="embed-responsive embed-responsive-16by9"><iframe class="embed-responsive-item vimeo-player" type="text/html" width="500" height="281" src="https://player.vimeo.com/video/19706846" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe></div></p>
+.
+.
+@[vimeo](https://vimeo.com/video/19706846)
+.
+<p><div class="embed-responsive embed-responsive-16by9"><iframe class="embed-responsive-item vimeo-player" type="text/html" width="500" height="281" src="https://player.vimeo.com/video/19706846" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe></div></p>
+.
+.
+@[vimeo](//vimeo.com/119932781)
+.
+<p><div class="embed-responsive embed-responsive-16by9"><iframe class="embed-responsive-item vimeo-player" type="text/html" width="500" height="281" src="https://player.vimeo.com/video/119932781" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe></div></p>
+.
+.
+@[vimeo](http://vimeo.com/119932781)
+.
+<p><div class="embed-responsive embed-responsive-16by9"><iframe class="embed-responsive-item vimeo-player" type="text/html" width="500" height="281" src="https://player.vimeo.com/video/119932781" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe></div></p>
+.
+
+Ignore text after digits in videoID if URL is specified
+.
+@[vimeo](http://vimeo.com/119932781x)
+.
+<p><div class="embed-responsive embed-responsive-16by9"><iframe class="embed-responsive-item vimeo-player" type="text/html" width="500" height="281" src="https://player.vimeo.com/video/119932781" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe></div></p>
+.
+
+Ignore scheme
+.
+@[vimeo](ftp://vimeo.com/119932781)
+.
+<p><div class="embed-responsive embed-responsive-16by9"><iframe class="embed-responsive-item vimeo-player" type="text/html" width="500" height="281" src="https://player.vimeo.com/video/119932781" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe></div></p>
+.
+.
+@[vimeo](anything://vimeo.com/119932781)
+.
+<p><div class="embed-responsive embed-responsive-16by9"><iframe class="embed-responsive-item vimeo-player" type="text/html" width="500" height="281" src="https://player.vimeo.com/video/119932781" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe></div></p>
+.
+
+Include full URL as videoID if it cannot be parsed
+.
+@[vimeo](http://unrecognized.vimeo.com/119932781)
+.
+<p><div class="embed-responsive embed-responsive-16by9"><iframe class="embed-responsive-item vimeo-player" type="text/html" width="500" height="281" src="https://player.vimeo.com/video/http://unrecognized.vimeo.com/119932781" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe></div></p>
 .
 
 Coverage. Vine


### PR DESCRIPTION
This PR includes the update to the Vimeo regex from https://github.com/CenterForOpenScience/markdown-it-video/pull/37 by @manolino, and includes tests.

About the tests:

I simply looked at the regex and the current behavior of the plugin to create the tests. I'm not sure if that behavior is correct in all cases, for example, look at these testcases in `test/fixtures/video.txt`:

- Include text after digits in videoID if only videoID is specified
- Ignore text after digits in videoID if URL is specified
- Ignore scheme
