### PR TITLE
feat: local video using default html5 video player

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,22 @@ Alternately, you could use the url.
 @[osf](https://mfr.osf.io/render?url=https://osf.io/kuvg9/?action=download)
 ```
 
+#### Local video
+
+This mode results in default HTML5 video player using the given url as source.
+The url can point to external source or something relative for current path.
+
+```md
+@[local](test_video.webm)
+```
+
+is interpreted as
+
+```html
+<p><video controls="true" allowfullscreen="true"><source src="test_video.webm" /></video></p>
+```
+
+
 ## Options
 
 ```js

--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@
 // Process @[vine](vineVideoID)
 // Process @[prezi](preziID)
 // Process @[osf](guid)
+// Process @[local](url)
 
 const ytRegex = /^.*((youtu.be\/)|(v\/)|(\/u\/\w\/)|(embed\/)|(watch\?))\??v?=?([^#&?]*).*/;
 function youtubeParser(url) {
@@ -74,6 +75,8 @@ function videoEmbed(md, options) {
       videoID = preziParser(videoID);
     } else if (serviceLower === 'osf') {
       videoID = mfrParser(videoID);
+    } else if (serviceLower === 'local') {
+      // videoID = videoID;
     } else if (!options[serviceLower]) {
       return false;
     }
@@ -176,6 +179,8 @@ function videoUrl(service, videoID, url, options) {
         'landing_sign=1kD6c0N6aYpMUS0wxnQjxzSqZlEB8qNFdxtdjYhwSuI';
     case 'osf':
       return 'https://mfr.osf.io/render?url=https://osf.io/' + videoID + '/?action=download';
+    case 'local':
+      return videoID;
     default:
       return service;
   }
@@ -202,6 +207,18 @@ function tokenizeVideo(md, options) {
         '    }); </script>';
     }
 
+    if (service === 'local' && videoID) {
+      const localPlayerAttrs = [];
+
+      const keys = Object.keys(options[service]);
+      const values = Object.values(options[service]);
+
+      for (let i = 0; i < keys.length; i += 1) {
+        localPlayerAttrs.push(keys[i] + '="' + values[i] + '"');
+      }
+      return '<video ' + localPlayerAttrs.join(' ') + '><source src="' + videoID + '" type="video/webm" /></video>';
+    }
+
     return videoID === '' ? '' :
       '<div class="embed-responsive embed-responsive-16by9"><iframe class="embed-responsive-item ' +
       service + '-player" type="text/html" width="' + (options[service].width) +
@@ -220,6 +237,7 @@ const defaults = {
   vine: { width: 600, height: 600, embed: 'simple' },
   prezi: { width: 550, height: 400 },
   osf: { width: '100%', height: '100%' },
+  local: { controls: true, allowfullscreen: true },
 };
 
 module.exports = function videoPlugin(md, options) {

--- a/test/fixtures/video.txt
+++ b/test/fixtures/video.txt
@@ -401,6 +401,13 @@ Coverage. Prezi from URL
 <p><div class="embed-responsive embed-responsive-16by9"><iframe class="embed-responsive-item prezi-player" type="text/html" width="550" height="400" src="https://prezi.com/embed/1kkxdtlp4241/?bgcolor=ffffff&amp;lock_to_path=0&amp;autoplay=0&amp;autohide_ctrls=0&amp;landing_data=bHVZZmNaNDBIWnNjdEVENDRhZDFNZGNIUE43MHdLNWpsdFJLb2ZHanI5N1lQVHkxSHFxazZ0UUNCRHloSXZROHh3PT0&amp;landing_sign=1kD6c0N6aYpMUS0wxnQjxzSqZlEB8qNFdxtdjYhwSuI" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe></div></p>
 .
 
+Coverage. Local from URL
+.
+@[local](test_video.webm)
+.
+<p><video controls="true" allowfullscreen="true"><source src="test_video.webm" type="video/webm" /></video></p>
+.
+
 Coverage. Line Breaks
 .
 @[vine](MhQ2lvg29Un) @[vine](MhQ2lvg29Un)

--- a/test/test.js
+++ b/test/test.js
@@ -32,6 +32,10 @@ describe('markdown-it-video: options', function () {
         autoplay: 0,
       },
     },
+    local: {
+      controls: false,
+      allowfullscreen: false,
+    },
   });
   var renderedHtml;
 
@@ -43,6 +47,11 @@ describe('markdown-it-video: options', function () {
   it('overwrite parameter', function () {
     renderedHtml = md.render('@[youtube](youtube.com/embed/0zM3nApSvMg?autoplay=1&rel=0)');
     assert.equal(renderedHtml, '<p><div class="embed-responsive embed-responsive-16by9"><iframe class="embed-responsive-item youtube-player" type="text/html" width="640" height="390" src="https://www.youtube-nocookie.com/embed/0zM3nApSvMg?autoplay=0&rel=0&fs=0" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe></div></p>\n');
+  });
+
+  it('local options', function () {
+    renderedHtml = md.render('@[local](test_video.webm)');
+    assert.equal(renderedHtml, '<p><video controls="false" allowfullscreen="false"><source src="test_video.webm" type="video/webm" /></video></p>\n');
   });
 });
 


### PR DESCRIPTION
Adds possibility to write "local" video url, like this:
```md
@[local](test_video.webm)
```

This renders the default html5 video player with the given url as the source.